### PR TITLE
remove go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x' ]
+        go: [ '1.22.x', '1.23.x', '1.24.x', '1.25.x' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: test


### PR DESCRIPTION
**Describe the PR**
Security upgrade broke the pipeline. Removing go1.21

**Relation issue**
e.g. https://github.com/swaggo/buffalo-swagger/pull/123/files

**Additional context**
Add any other context about the problem here.
